### PR TITLE
Optionally fit for redshift and a Gaussian kernel at test time

### DIFF
--- a/AnniesLasso/cannon.py
+++ b/AnniesLasso/cannon.py
@@ -406,7 +406,7 @@ def _fit_spectrum(normalized_flux, normalized_ivar, dispersion, initial_labels,
             y = np.interp(dispersion, dispersion * (1 + parameters[index]), y,
                 left=None, right=None)
 
-        return y
+        return y[use]
 
 
     kwds = {
@@ -462,8 +462,13 @@ def _fit_spectrum(normalized_flux, normalized_ivar, dispersion, initial_labels,
         # We are in dire straits. We should not trust the result.
         op_labels *= np.nan
 
+    # Defaults for LSF/redshift parameters
+    meta.update(kernel=0, redshift=0)
+    for key, effect in zip(("kernel", "redshift"), (model_lsf, model_redshift)):
+        if effect:
+            meta[key] = op_labels[-1]
+            op_labels[:-1]
     
-
     # Save additional information.
     meta.update({
         "best_result_index": best_result_index,

--- a/AnniesLasso/cannon.py
+++ b/AnniesLasso/cannon.py
@@ -275,14 +275,11 @@ class CannonModel(model.BaseCannonModel):
 
         s = []
         for j in range(self.dispersion.size):
-            print(j)
             s.append(op.fmin(objective_function, 0,
                 args=(residuals_squared[:, j], self.normalized_ivar[:, j]), 
                 disp=False))
 
-        s2 = np.array(s)**2
-        s2[s2 == 0] = np.inf
-        self.s2 = s2
+        self.s2 = np.array(s)**2
         return True
 
 
@@ -426,12 +423,12 @@ def _fit_spectrum(normalized_flux, normalized_ivar, dispersion, initial_labels,
     }
 
     # Only update the keywords with things that op.curve_fit/op.leastsq expects.
-    kwds.update(
-        { k: kwargs[k] for k in set(kwargs).intersection(kwds) if k != "Dfun" })
+    for key in set(kwargs).intersection(kwds):
+        if key == "Dfun": continue
+        kwds[key] = kwargs[key]
+
 
     results = []
-    
-    # Go through the initial labels.
     for p0 in np.atleast_2d(initial_labels):
         kwds["p0"] = list(p0)
         

--- a/sandbox-scripts/sandbox_redshift_lsf.py
+++ b/sandbox-scripts/sandbox_redshift_lsf.py
@@ -1,0 +1,60 @@
+
+""" Sandbox area for testing redshift and LSF fitting at test time. """
+
+import numpy as np
+import os
+from six.moves import cPickle as pickle
+from astropy.table import Table
+
+import AnniesLasso as tc
+
+# Data.
+PATH, CATALOG, FILE_FORMAT = ("", "apogee-rg.fits",
+    "apogee-rg-custom-normalization-{}.memmap")
+
+# Load the data.
+labelled_set = Table.read(os.path.join(PATH, CATALOG))
+dispersion = np.memmap(os.path.join(PATH, FILE_FORMAT).format("dispersion"),
+    mode="c", dtype=float)
+normalized_flux = np.memmap(
+    os.path.join(PATH, FILE_FORMAT).format("flux"),
+    mode="c", dtype=float).reshape((len(labelled_set), -1))
+normalized_ivar = np.memmap(
+    os.path.join(PATH, FILE_FORMAT).format("ivar"),
+    mode="c", dtype=float).reshape(normalized_flux.shape)
+
+# Identify the training set used previously.
+np.random.seed(123) # For reproducibility.
+training_set = (np.random.randint(0, 10, len(labelled_set)) > 0)
+
+if not os.path.exists("testing-redshift-model.pkl"):
+
+    # Create a spectral model.
+    model = tc.L1RegularizedCannonModel(labelled_set[training_set],
+        normalized_flux[training_set], normalized_ivar[training_set],
+        dispersion=dispersion, threads=8)
+
+    model.vectorizer = tc.vectorizer.NormalizedPolynomialVectorizer(labelled_set,
+        tc.vectorizer.polynomial.terminator(("TEFF", "LOGG", "FE_H"), 2))
+
+    model.s2 = 0.0
+    model.regularization = 0
+
+    model.train()
+    model._set_s2_by_hogg_heuristic()
+
+    model.save("testing-redshift-model.pkl", True)
+
+
+else:
+    model = tc.load_model("testing-redshift-model.pkl")
+
+
+foo = model.fit(normalized_flux[650], normalized_ivar[650],  model_redshift=True,
+    full_output=True)
+bar = model.fit(normalized_flux[650], normalized_ivar[650], full_output=True)
+
+moo = model.fit(normalized_flux[650], normalized_ivar[650],  model_lsf=True,
+    full_output=True)
+cow = model.fit(normalized_flux[650], normalized_ivar[650], model_lsf=True,
+    model_redshift=True, full_output=True)


### PR DESCRIPTION
This PR allows for the redshift and "line spread function" (LSF) to be optionally fitted at test time by using the `model_redshift` and `model_lsf` keyword arguments in `model.fit()`.

The output has the same structure: only the labels are returned unless `full_output=True`. If `full_output` is enabled then a three-length tuple is returned: `(labels, covariance_matrix, metadata)`. The `redshift` and `kernel` values are stored in the metadata dictionary (these are zero if `model_*` were not enabled).

The redshift and "LSF" are modelled here as very poor approximations. Redshifted spectra are linearly interpolated onto the common dispersion points (e.g., no proper resampling), and the "LSF" is modelled by a convolution with a single Gaussian kernel. The redshift approximation is OK for most purposes. Once @davidwhogg's LaTeX one-pager on the convolution is ready (or we have just worked out what we want to include), I will implement that.

/cc #46 #63